### PR TITLE
File size culling

### DIFF
--- a/Dirlist.hh
+++ b/Dirlist.hh
@@ -25,7 +25,7 @@ private:
 
   // where to report found files. this is called for every item in all
   // directories found by walk.
-  typedef int (*reportfcntype)(const std::string&, const std::string&, int);
+  typedef int (*reportfcntype)(const std::string&, const std::string&, const unsigned long, const unsigned long, int);
 
   // called when a regular file or a symlink is encountered
   reportfcntype m_callback;
@@ -33,11 +33,15 @@ private:
   // a function that is called from walk when a non-directory is encountered
   // for instance,if walk("/path/to/a/file.ext") is called instead of
   // walk("/path/to/a/")
-  int handlepossiblefile(const std::string& possiblefile, int recursionlevel);
+  int handlepossiblefile(const std::string& possiblefile,
+			  const unsigned long minfilesizefilter, const unsigned long maxfilesizefilter,
+			  int recursionlevel);
 
 public:
   // find all files on a specific place
-  int walk(const std::string& dir, const int recursionlevel = 0);
+  int walk(const std::string& dir,
+	   const unsigned long minfilesizefilter, const unsigned long maxfilesizefilter,
+	   const int recursionlevel = 0);
 
   // to set the report functions
   void setcallbackfcn(reportfcntype reportfcn) { m_callback = reportfcn; }

--- a/rdfind.1
+++ b/rdfind.1
@@ -147,6 +147,7 @@ MAX_SIZE=$(( 1000 * 1000000 ))	# 1000 megabytes = 1 gig
 for i in 250 10 2 1 0.5 0.25 0; do
     MIN_SIZE=$( echo "scale=0; ($i * 1000000)/1" | bc)  # i * megabyte
     DATESTR=$(date +%Y%m%d_%H:%M:%S)
+    # The following command can be dispatched to multiple machines or cores to run in parallel
     { time rdfind -outputname results_min_${MIN_SIZE}_max_${MAX_SIZE}_${DATESTR}.txt -minFileSize ${MIN_SIZE} -maxFileSize ${MAX_SIZE} ./dir1 ./dir2 ./dir3 ; } 2>&1 | tee -a results_min_${MIN_SIZE}_max_${MAX_SIZE}_${DATESTR}.log
     MAX_SIZE=$MIN_SIZE
 done
@@ -209,7 +210,7 @@ Several persons have helped with suggestions and improvements:
 Niels Möller, Carl Payne and Salvatore Ansani. Thanks also to you
 who tested the program and sent me feedback.
 .SH VERSION
-1.4.next (release date 2019-05-03)
+1.4.next (release date 2018-xx-xx)
 .SH COPYRIGHT
 This program is distributed under GPLv2 or later, at your option.
 .SH "SEE ALSO"

--- a/rdfind.1
+++ b/rdfind.1
@@ -65,6 +65,16 @@ Ignore empty files. Setting this to true (the default) is equivalent to
 Ignores files with less than N bytes. Default is 1, meaning empty files
 are ignored.
 .TP
+.BR \-minFileSize " "\fIN\fR
+Ignores files with less than N bytes. Default is 1, meaning empty files
+are ignored.
+.TP
+.BR \-maxFileSize " "\fIN\fR
+Ignores files with more than N bytes. Default is ULONG_MAX, meaning no files
+are ignored. When used in conjunction with -minFileSize only files within the
+range of sizes are operated upon.  This allows for parallelization and dividing
+deduplication runs into smaller jobs. (See Examples)
+.TP
 .BR \-followsymlinks " " \fItrue\fR|\fIfalse\fR
 Follow symlinks. Default is false.
 .TP
@@ -126,6 +136,26 @@ Delete duplicates in a backup directory:
 .TP
 Search for duplicate files in directories called foo:
 .B find . -type d -name foo -print0 |xargs -0 rdfind
+.TP
+Run in parallel using size partitioning to break-down a large deduplication job into smaller sub-jobs
+.B
+.PP
+.nf
+.RS
+#! /bin/bash
+MAX_SIZE=$(( 1000 * 1000000 ))	# 1000 megabytes = 1 gig
+for i in 250 10 2 1 0.5 0.25 0; do
+    MIN_SIZE=$( echo "scale=0; ($i * 1000000)/1" | bc)  # i * megabyte
+    DATESTR=$(date +%Y%m%d_%H:%M:%S)
+    { time rdfind -outputname results_min_${MIN_SIZE}_max_${MAX_SIZE}_${DATESTR}.txt -minFileSize ${MIN_SIZE} -maxFileSize ${MAX_SIZE} ./dir1 ./dir2 ./dir3 ; } 2>&1 | tee -a results_min_${MIN_SIZE}_max_${MAX_SIZE}_${DATESTR}.log
+    MAX_SIZE=$MIN_SIZE
+done
+exit
+.RE
+.fi
+.PP
+
+
 .SH FILES
 .I results.txt
 (the default name is results.txt and can be changed with option outputname,
@@ -142,6 +172,7 @@ the directory in the same input argument as the original)
 
 DUPTYPE_OUTSIDE_TREE the file is found during processing another input
 argument than the original. 
+
 .SH ENVIRONMENT
 .SH DIAGNOSTICS
 .SH EXIT VALUES
@@ -171,12 +202,14 @@ Rdfind can be found at https://rdfind.pauldreik.se/
 Do you find rdfind useful? Drop me a line! It is always fun to
 hear from people who actually use it and what data collections
 they run it on.
+
+Size partitioning options and scripts by Don Hejna
 .SH THANKS
 Several persons have helped with suggestions and improvements:
 Niels Möller, Carl Payne and Salvatore Ansani. Thanks also to you
 who tested the program and sent me feedback.
 .SH VERSION
-1.4.next (release date 2018-xx-xx)
+1.4.next (release date 2019-05-03)
 .SH COPYRIGHT
 This program is distributed under GPLv2 or later, at your option.
 .SH "SEE ALSO"

--- a/rdfind_by_size.sh
+++ b/rdfind_by_size.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+#set -x
+
+DIRLIST="./dir1 ./dir2 ./dir3"
+RDFIND=rdfind
+
+DRYRUN_VAL="false"
+REMOVEIDENTINODE_VAL="true"
+
+MAX_SIZE=$(( 1000 * 1000000 ))	# 1000 megabytes = 1 gig
+# Walk down in size creating groups of files in size bands to work on
+for i in 20 10 5 4 3 2 1 0.75 0.5 0.25 0; do
+    if [ -e stoprdfind ]
+    then
+	exit
+    else
+	echo "Proceeding..."
+    fi
+    MIN_SIZE=$( echo "scale=0; ($i * 1000000)/1" | bc)  # i * megabyte
+    printf "MAX_SIZE = %'d\n" $MAX_SIZE
+    printf "MIN_SIZE = %'d\n" $MIN_SIZE
+    echo " .. "
+    DATESTR=$(date +%Y%m%d_%H:%M:%S)
+    # The following command can be dispatched to multiple machines or cores to run in parallel
+    { time ${RDFIND} -dryrun ${DRYRUN_VAL} -removeidentinode ${REMOVEIDENTINODE_VAL} -makehardlinks true -checksum sha1 -outputname results_min_${MIN_SIZE}_max_${MAX_SIZE}_${DATESTR}.txt -minFileSize ${MIN_SIZE} -maxFileSize ${MAX_SIZE} ${DIRLIST} ; } 2>&1 | tee -a results_min_${MIN_SIZE}_max_${MAX_SIZE}_${DATESTR}.log
+
+    MAX_SIZE=$MIN_SIZE 		# step down to next size
+done
+exit


### PR DESCRIPTION
This implements the feature in #23.
The code is functional but has redundancy with -minSize that needs to be resolved pending discussion.  Consider it a working example.   The value of the size filtering is best appreciated in the rdfind_by_size.sh script.

## Implementation Notes: 
I made a custom version of rdfind based on 1.3.5 which implemented the feature I have relied upon and found useful for a few years.  In my implementation, I passed two additional const arguments (minfilesizefilter, maxfilesizefilter) down through the call chain that is active while walking the directory structures all in order to get to the report function (which is where files are added.  Punching in two global variables would potentially have been cleaner but it was not clear to me at the time how to safely do that and have it persist, and I was contemplating doing other things along the way with the file tests such as adding regex support in different directories for culling files.  I can rewrite to the global method easily if desired.

In 1.4 I see Paul had added minSize and has done so in a more elegant way given my knowledge of the code at the time I made the changes.  I think it may be more elegant to add the filter function only to the tmp() function in report () as Paul has exemplified in 1.4.  However that variable is overloaded in that it is also used to convey information on the zero file option.  Thus my initial port to 1.4 now creates a redundant “minFile size” argument which should be cleaned up after some sorting out of how conflicting commandline specifications of minSize and -ignoreempty are resolved.

Additionally, it should be noted that the filter should accept the maximum filesize on an OS which is not necessarily defined in limits.h / climits and the test case for maxFileSize should include <= so that maxFileSize files can be tested.  This forces the top-level partitioning script to deal with inclusive size bands like 100 to 199 in one partitioned job and 200 to 299 in the subsequent as opposed to being able to write min=100 to max=200 and min=200 to max=300 if > and <= were used in the test conditions for min and max respectively which would allow for a common endpoint to be used in inclusive and exclusive intervals during the cull of files based on size. After some thought, I concluded that both min and max should have inclusive operational intervals on files sizes specified, to minimize user confusion, so “equals” are in order for the comparisons.

Also for speed purposes, it is faster to reject the “push” onto the queue on the first failed condition rather than test all size comparisons which is why i re-ordered the test conditions, although in theory a good compiler produces the same code for the logical “&&” tests.

