### PR TITLE
Add test for older Ubuntu and Raspbian distros which lack AX_CXX_COMPILE_STDCXX macro

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -8,6 +8,58 @@
 #bail out on error
 set -e
 
+if [ `lsb_release -i 2>/dev/null | grep -c "Ubuntu")` -eq 1 ] ;
+then
+    echo "Detected Ubuntu OS."
+    UBUNTU_OS=1
+else
+    echo "OS is not Ubuntu. Check AX_CXX_COMPILE_STDCXX macros in configure.ac if you have problems running ./congfigure."
+    echo "You will need the equivalent packages of Ubuntu's automake, autoconf-archive, g++, and nettle-dev on your OS."
+    UBUNTU_OS=0
+fi
+if [ $UBUNTU_OS -eq 1 ];
+then
+    PACKAGE_LIST="automake g++ autoconf-archive nettle-dev"
+    for PKG in ${PACKAGE_LIST} ; do
+	if [ $(dpkg-query -W -f='${Status}' ${PKG} 2>/dev/null | grep -c "ok installed") -eq 0 ] ;
+	then
+	    echo "${PKG} not installed or not on path.";
+	    echo "Run:  apt-get install ${PKG}";
+	    exit
+	else
+	    echo "Found required package: ${PKG}";
+	fi
+    done
+
+    # The following code is for older Ubuntu OS's which do not ship with the AX_CXX_COMPILE_STDCXX() macro in autoconf-archive"
+    #
+    # FRAGILE:  This code depends on the following two lines being present in configure.ac:
+    #   dnl AX_CXX_COMPILE_STDCXX_11([noext], [mandatory])
+    #   AX_CXX_COMPILE_STDCXX([11],[noext],[mandatory])
+
+    if [ `lsb_release -rs | cut -d. -f 1` -lt "18" ] ;
+    then
+	# less than 18:  Tested with 14.04 and 16.04, unsure of 17.X releases
+	echo "adjusting configure.ac file to use older C++ macro test. Preserving original in configure.ac.orig" ;
+	if [ -e configure.ac.orig ] ;
+	then
+	    echo "configure.ac.orig exists, preserving that copy."
+	else
+	    echo "copying configure.ac to configure.ac.orig"
+	    cp -p configure.ac configure.ac.orig # preserve original
+	fi
+	echo -n "rolling back m4 macro test in configure.ac... "
+	sed -i.bak -r 's/^(\s+)dnl\s+AX_CXX_COMPILE_STDCXX_11\(\[noext\], \[mandatory\]\)/\1AX_CXX_COMPILE_STDCXX_11\(\[noext\], \[mandatory\]\)/; s/AX_CXX_COMPILE_STDCXX\(\[11\],\[noext\],\[mandatory\]\)/dnl AX_CXX_COMPILE_STDCXX\(\[11\],\[noext\],\[mandatory\]\)/' configure.ac
+	echo "Done."
+	echo "If you make manual changes to configure.ac, rerun this script before running ./configure"
+
+    else
+	echo "Configure.ac needs no adjustment." ;
+    fi
+fi
+
+exit
+
 aclocal
 autoheader
 automake --add-missing

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -58,8 +58,6 @@ then
     fi
 fi
 
-exit
-
 aclocal
 autoheader
 automake --add-missing


### PR DESCRIPTION
This is based on @djhejna work to test for older Ubuntu versions.

I extended this to support older Raspbian versionens.
Tested with Raspbian 8.0.

It would be usefull to further extend this for vanialla Debian since oth Ubuntu and Raspbian are based on this.
But I have no system to test this.