### PR TITLE
Define "feature macros" for symlink, make it compilable on cygwin

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -57,12 +57,27 @@ AC_CHECK_LIB(nettle,main,,[AC_MSG_ERROR([
 ])])
 
 dnl make sure to set feature test macros to use symlink
-AC_DEFINE([_POSIX_C_SOURCE], [200112L], [Use extra functions such as symlink])
-AC_DEFINE([_XOPEN_SOURCE], [500], [Use extra functions such as symlink])
-dnl Commented out because for some reason cygwin sys/features.h defines
-dnl _DEFAULT_SOURCE when _BSD_SOURCE is defined and redefines _POSIX_C_SOURCE,
-dnl causing a redefinition warning when it reads the config.h again
-dnl AC_DEFINE([_BSD_SOURCE], [1], [Use extra functions such as symlink])
+AH_VERBATIM([_POSIX_C_SOURCE],
+          [/* Make "extra" functions available such as symlink() */
+          #ifndef _POSIX_C_SOURCE
+          # define _POSIX_C_SOURCE 200112L
+          #endif])
+AH_VERBATIM([_XOPEN_SOURCE],
+          [/* Make "extra" functions available such as symlink() */
+          #ifndef _XOPEN_SOURCE
+          # define _XOPEN_SOURCE 500
+          #endif])
+dnl defining _BSD_SOURCE causes a deprecation warning to use _DEFAULT_SOURCE instead
+dnl AH_VERBATIM([_BSD_SOURCE],
+dnl           [/* Make "extra" functions available such as symlink() */
+dnl           #ifndef _BSD_SOURCE
+dnl           # define _BSD_SOURCE 1
+dnl           #endif])
+AH_VERBATIM([_DEFAULT_SOURCE],
+          [/* Make "extra" functions available such as symlink() */
+          #ifndef _DEFAULT_SOURCE
+          # define _DEFAULT_SOURCE 1
+          #endif])
 
 dnl test for some specific functions
 AC_CHECK_FUNC(stat,,AC_MSG_ERROR(oops! no stat ?!?))

--- a/configure.ac
+++ b/configure.ac
@@ -62,22 +62,6 @@ AH_VERBATIM([_POSIX_C_SOURCE],
           #ifndef _POSIX_C_SOURCE
           # define _POSIX_C_SOURCE 200112L
           #endif])
-AH_VERBATIM([_XOPEN_SOURCE],
-          [/* Make "extra" functions available such as symlink() */
-          #ifndef _XOPEN_SOURCE
-          # define _XOPEN_SOURCE 500
-          #endif])
-dnl defining _BSD_SOURCE causes a deprecation warning to use _DEFAULT_SOURCE instead
-dnl AH_VERBATIM([_BSD_SOURCE],
-dnl           [/* Make "extra" functions available such as symlink() */
-dnl           #ifndef _BSD_SOURCE
-dnl           # define _BSD_SOURCE 1
-dnl           #endif])
-AH_VERBATIM([_DEFAULT_SOURCE],
-          [/* Make "extra" functions available such as symlink() */
-          #ifndef _DEFAULT_SOURCE
-          # define _DEFAULT_SOURCE 1
-          #endif])
 
 dnl test for some specific functions
 AC_CHECK_FUNC(stat,,AC_MSG_ERROR(oops! no stat ?!?))

--- a/configure.ac
+++ b/configure.ac
@@ -56,6 +56,14 @@ AC_CHECK_LIB(nettle,main,,[AC_MSG_ERROR([
  and try again.
 ])])
 
+dnl make sure to set feature test macros to use symlink
+AC_DEFINE([_POSIX_C_SOURCE], [200112L], [Use extra functions such as symlink])
+AC_DEFINE([_XOPEN_SOURCE], [500], [Use extra functions such as symlink])
+dnl Commented out because for some reason cygwin sys/features.h defines
+dnl _DEFAULT_SOURCE when _BSD_SOURCE is defined and redefines _POSIX_C_SOURCE,
+dnl causing a redefinition warning when it reads the config.h again
+dnl AC_DEFINE([_BSD_SOURCE], [1], [Use extra functions such as symlink])
+
 dnl test for some specific functions
 AC_CHECK_FUNC(stat,,AC_MSG_ERROR(oops! no stat ?!?))
 


### PR DESCRIPTION
Define `_XOPEN_SOURCE` and `_POSIX_C_SOURCE` appropriately in order to be able to use functions such as `symlink()` on cygwin.

Before that it would error while running make about not being able to find a function called `symlink`. After looking into the header files, I've found it requires at least one of those macros in order to be defined.

The error was:

```
g++ -std=c++11 -DHAVE_CONFIG_H -I.     -g -O2 -MT Fileinfo.o -MD -MP -MF .deps/Fileinfo.Tpo -c -o Fileinfo.o Fileinfo.cc
Fileinfo.cc: In lambda function:
Fileinfo.cc:280:14: error: ‘symlink’ was not declared in this scope
       return symlink(target.c_str(), filename.c_str());
              ^~~~~~~
Fileinfo.cc:280:14: note: suggested alternative: ‘unlink’
       return symlink(target.c_str(), filename.c_str());
              ^~~~~~~
              unlink
```

Additionally, `man 2 symlink` (on Ubuntu 18.04) says, it'll be defined for:

```
    _XOPEN_SOURCE >= 500 || _POSIX_C_SOURCE >= 200112L
        || /* Glibc versions <= 2.19: */ _BSD_SOURCE
```

However, defining `_BSD_SOURCE` would cause cygwin `sys/feature.h` to define `_DEFAULT_SOURCE`, which in turns always redefines `_POSIX_C_SOURCE`, causing an redefinition warning when the `config.h` file is processed again. Thus `_BSD_SOURCE` isn't defined, for now.

This is also my first time modifying autoconfig files. I hope I did everything alright. Note that it just builds and is functional (can find duplicates), but I haven't tried anything advanced yet (like dryrun, actually soft or hard symlinking).