### PR TITLE
Clarify that -makeresultsfile does not disable deletions

### DIFF
--- a/rdfind.1
+++ b/rdfind.1
@@ -95,7 +95,8 @@ Replace duplicate files with hard links. Default is false.
 .TP
 .BR \-makeresultsfile " " \fItrue\fR|\fIfalse\fR
 Make a results file in the current directory. Default is true. If the
-file exists, it is overwritten.
+file exists, it is overwritten. This does not affect whether items are
+deleted. See -dryrun for how to disable deletions.
 .TP
 .BR \-outputname " " \fIname\fR
 Make the results file name to be "name" instead of the default


### PR DESCRIPTION
Just checking out this program today and I got the mistaken impression that -makeresultsfile was true by default and that as a result, nothing would be deleted. Boy was I wrong! I caught this before running it by reading the man file, but I almost missed it. I think a pointer to `-dryrun` would be helpful here.