### PR TITLE
Add support for ignoring specified directory names 

### DIFF
--- a/Dirlist.hh
+++ b/Dirlist.hh
@@ -8,20 +8,26 @@
 #define Dirlist_hh
 
 #include <string>
+#include <vector>
 
 /// class that traverses a directory
 class Dirlist
 {
 public:
   // constructor
-  explicit Dirlist(bool followsymlinks)
+  explicit Dirlist(bool followsymlinks, std::string ignoredirs)
     : m_followsymlinks(followsymlinks)
     , m_callback(nullptr)
-  {}
+  {
+    parseignoredirs(ignoredirs);
+  }
 
 private:
   // follow symlinks or not
   bool m_followsymlinks;
+
+  // directory names to ignore
+  std::vector<std::string> m_ignoredirs;
 
   // where to report found files. this is called for every item in all
   // directories found by walk.
@@ -34,6 +40,10 @@ private:
   // for instance,if walk("/path/to/a/file.ext") is called instead of
   // walk("/path/to/a/")
   int handlepossiblefile(const std::string& possiblefile, int recursionlevel);
+
+  // parse a space separated string of directory names to be ignored into a
+  // vector of strings
+  void parseignoredirs(std::string ignoredirs);
 
 public:
   // find all files on a specific place

--- a/rdfind.cc
+++ b/rdfind.cc
@@ -53,6 +53,10 @@ usage()
     << " -ignoreempty      (true)| false  ignore empty files (true implies "
        "-minsize 1,\n"
     << "                                  false implies -minsize 0)\n"
+    << " -ignoredirs names                ignores directory names in the space "
+       "separated list \"names\"\n"
+    << "                                  example: -ignoredirs \"foo bar baz\" "
+       "default: \"\"\n"
     << " -minsize N        (N=1)          ignores files with size less than N "
        "bytes\n"
     << " -maxsize N        (N=0)          ignores files with size N "
@@ -108,6 +112,7 @@ struct Options
   bool deterministic = true; // be independent of filesystem order
   long nsecsleep = 0; // number of nanoseconds to sleep between each file read.
   std::string resultsfile = "results.txt"; // results file name.
+  std::string ignoredirs = ""; // directory names to be ignored
 };
 
 Options
@@ -136,6 +141,8 @@ parseOptions(Parser& parser)
       o.makeresultsfile = parser.get_parsed_bool();
     } else if (parser.try_parse_string("-outputname")) {
       o.resultsfile = parser.get_parsed_string();
+    } else if (parser.try_parse_string("-ignoredirs")) {
+      o.ignoredirs = parser.get_parsed_string();
     } else if (parser.try_parse_bool("-ignoreempty")) {
       if (parser.get_parsed_bool()) {
         o.minimumfilesize = 1;
@@ -289,7 +296,7 @@ main(int narg, const char* argv[])
   Rdutil gswd(filelist);
 
   // an object to traverse the directory structure
-  Dirlist dirlist(o.followsymlinks);
+  Dirlist dirlist(o.followsymlinks, o.ignoredirs);
 
   // this is what function is called when an object is found on
   // the directory traversed by walk. Make sure the pointer to the


### PR DESCRIPTION
This set of changes adds an -ignoredirs command line option which takes a string containing a space separated list of directory names to be ignored. This supports a use case where there are some directories which may contain intentional duplicates. For example, I keep unaltered read only copies of books in a directory named "originals" and potentially annotated copies in another directory.

```
Books/
    book1.pdf
    book2.pdf
    book3.pdf
    originals/
        book1.pdf
        book2.pdf
        book3.pdf
```

Then run rdfind as:
```
cd Books
rdfind -ignoredirs "originals" .
```
