### PR TITLE
Added -rememberidentinode option which better handles hardlink groups

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -18,7 +18,8 @@ TESTS=testcases/largefilesupport.sh \
       testcases/verify_deterministic_operation.sh \
       testcases/checksum_options.sh \
       testcases/md5collisions.sh \
-      testcases/sha1collisions.sh
+      testcases/sha1collisions.sh \
+      testcases/hardlink_groups.sh
 
 AUXFILES=testcases/common_funcs.sh \
          testcases/md5collisions/letter_of_rec.ps \

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Rdfind uses the following algorithm. If N is the number of files to search throu
 2. For each argument, list the directory contents recursively and assign it to the file list. Assign a directory depth number, starting at 0 for every argument.
 3. If the input argument is a file, add it to the file list.
 4. Loop over the list, and find out the sizes of all files.
-5. If flag -removeidentinode true: Remove items from the list which already are added, based on the combination of inode and device number. A group of files that are hardlinked to the same file are collapsed to one entry. Also see the comment on hardlinks under ”caveats below”!
+5. If flag -removeidentinode true: Remove items from the list which already are added, based on the combination of inode and device number. A group of files that are hardlinked to the same file are collapsed to one entry. If flag -rememberidentinode true the removed files are rememberd and included in the final result. Also see the comment on hardlinks under ”caveats below”!
 6. Sort files on size. Remove files from the list, which have unique sizes.
 7. Sort on device and inode(speeds up file reading). Read a few bytes from the beginning of each file (first bytes).
 8. Remove files from list that have the same size but different first bytes.

--- a/Rdutil.hh
+++ b/Rdutil.hh
@@ -46,7 +46,7 @@ public:
    * rank.
    * @return number of elements removed
    */
-  std::size_t removeIdenticalInodes();
+  std::size_t removeIdenticalInodes(bool rememberIdenticalInodes);
 
   /**
    * remove files with unique size from the list.
@@ -121,6 +121,20 @@ public:
 
 private:
   std::vector<Fileinfo>& m_list;
+
+  std::vector<Fileinfo> m_identlist;
+
+  typedef std::vector<Fileinfo>::iterator FileIter;
+
+  std::vector<FileIter> m_identindex;
+
+  void move_deletes_to_duplist();
+
+  std::pair<FileIter,FileIter> find_identical_inodes(const FileIter listpos) const;
+
+  template<typename Function> std::size_t applyactiononfile(Function f) const;
+
+  template<typename Function> void process_result(Function f) const;
 };
 
 #endif

--- a/rdfind.1
+++ b/rdfind.1
@@ -74,7 +74,12 @@ Follow symlinks. Default is false.
 .TP
 .BR \-removeidentinode " " \fItrue\fR|\fIfalse\fR
 Removes items found which have identical inode and device ID. Default
-is true.
+is true. Consider using -rememberidentinode true instead of -removeidentinode false.
+.TP
+.BR \-rememberidentinode " " \fItrue\fR|\fIfalse\fR
+Removes but remembers items found which have identical inode and device ID and adds
+them again in the final result. Runs faster and reports more accurate statistics
+than with  -removeidentinode false. Implies -removeidentinode true. Default is false.
 .TP
 .BR \-checksum " " \fImd5\fR|\fIsha1\fR|\fIsha256\fR
 What type of checksum to be used: md5, sha1 or sha256. The default is

--- a/testcases/hardlink_groups.sh
+++ b/testcases/hardlink_groups.sh
@@ -1,0 +1,93 @@
+#!/bin/sh
+# Investigate what happen when symlinking fails.
+#
+
+
+set -e
+. "$(dirname "$0")/common_funcs.sh"
+
+reset_teststate
+
+assert_eq() {
+  message="$1"
+  actual="$2"
+  expected="$3"
+  if [ "$expected" != "$actual" ]; then
+    dbgecho "ASSERTION FAILED [$message], expected '$expected' but was '$actual'"
+    exit 1
+  fi
+}
+
+make_files() {
+  head -c 1000000 </dev/urandom > a
+  ln a a1
+  ln a a2
+  cp a A
+  ln A A1
+  ln A A2
+
+  head -c 1000000 </dev/urandom > b
+  ln b b1
+  ln b b2
+  cp b B
+  ln B B1
+  ln B B2
+}
+
+verify_result() {
+  assert_eq "number of files" $(ls | wc -l) 12
+  assert_eq "number of hardlinks to a" $(stat -c %h $datadir/a) 6
+  assert_eq "number of hardlinks to b" $(stat -c %h $datadir/b) 6
+  if cmp --silent $datadir/a $datadir/b; then
+    dbgecho "Files should be different"
+    exit 1
+  fi
+}
+
+# <expected_reported_reduction> <expected_actual_reduction> <expected_created_hardlinks> [rdfind_option...]
+verify_reduction_with_options() {
+  expected_reported="$1"
+  expected_reduction="$2"
+  expected_links="$3"
+  shift 3
+
+  size_before=$(du -m "$datadir" | cut -f1)
+
+  $rdfind -makehardlinks true "$@" "$datadir" | tee rdfind.out
+
+  assert_eq "reported reduction" "$(cat rdfind.out | grep Totally | sed 's/Totally, \([^ ]*\).*/\1/')" "$expected_reported"
+  assert_eq "number of creaded hardlinks" "$(cat rdfind.out | grep Making | sed 's/Making \([^ ]*\).*/\1/')" "$expected_links"
+
+  rm rdfind.out results.txt
+  size_after=$(du -m "$datadir" | cut -f1)
+  assert_eq "actual reduction" $(( $size_before - $size_after )) "$expected_reduction"
+}
+
+# Default behavior
+# requires multiple runs and reports incorrect reduction
+make_files
+verify_reduction_with_options 2 0 2 -removeidentinode true
+verify_reduction_with_options 2 0 2 -removeidentinode true
+verify_reduction_with_options 2 2 2 -removeidentinode true
+verify_result
+verify_reduction_with_options 0 0 0 -removeidentinode true
+verify_result
+
+# removeidentinode false
+# requires single run but reports incorrect reduction and number of created links
+# also does too much work and keeps repeating it all even when no reduction can be gained
+reset_teststate
+make_files
+verify_reduction_with_options 10 2 10 -removeidentinode false
+verify_result
+verify_reduction_with_options 10 0 10 -removeidentinode false
+verify_result
+
+# rememberidentinode true
+# requires single run and reports correct statistics
+reset_teststate
+make_files
+verify_reduction_with_options 2 2 6 -rememberidentinode true
+verify_result
+verify_reduction_with_options 0 0 0 -rememberidentinode true
+verify_result


### PR DESCRIPTION
I added the option -rememberidentinode which better handles hardlink groups. I tried to keep the changes to the code at a minimum level and impact on performance of existing behavior neglectable. With the new option enabled hardlink groups are more or less handled as with -removeidentinode false while the performance is close to that of the default behavior.

This can make a big difference. These are some results from a test using the different options on three snapshots of some data taken with rsnapshot:

```
with options -makehardlinks true -removeidentinode true
RUN 1, 58s,  reported saving 4G, actual saving 0G
RUN 2, 57s,  reported saving 4G, actual saving 0G
RUN 3, 58s,  reported saving 4G, actual saving 4G
RUN 4, 1.5s, reported saving 0G, actual saving 0G

with options -makehardlinks true -removeidentinode false
RUN 1, 5m9s,  reported saving 57G, actual saving 4G
RUN 2, 5m53s, reported saving 57G, actual saving 0G

with options -makehardlinks true -rememberidentinode true
RUN 1, 55s,  reported saving 4G, actual saving 4G
RUN 2, 1.5s, reported savin 0G, actual saving 0G
```

However, I had almost zero experience with C++ so I'm sure the code can be improved. Please let me know what you think.
