### PR TITLE
rename 'remove' to 'exclude' when referring to candidate list

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2021-04-21 Eoghan Murray
+        * change terminology to prefer 'exclude' over 'remove' when talking
+	  about the file list, in case there's confusion between 'remove' and
+	  'delete'
+	* as per above, rename option -removeidentinode to -excludeidentinode
 2018-11-12 Paul Dreik <rdfind@pauldreik.se>
         * release of 1.4.1
         * fixes build failure on 32 bit platforms

--- a/Rdutil.cc
+++ b/Rdutil.cc
@@ -298,7 +298,7 @@ Rdutil::sort_on_depth_and_name(std::size_t index_of_first)
 }
 
 std::size_t
-Rdutil::removeIdenticalInodes()
+Rdutil::excludeIdenticalInodes()
 {
   // sort list on device and inode.
   auto cmp = cmpDeviceInode;
@@ -319,7 +319,7 @@ Rdutil::removeIdenticalInodes()
 }
 
 std::size_t
-Rdutil::removeUniqueSizes()
+Rdutil::excludeUniqueSizes()
 {
   // sort list on size
   auto cmp = cmpSize;
@@ -341,7 +341,7 @@ Rdutil::removeUniqueSizes()
 }
 
 std::size_t
-Rdutil::removeUniqSizeAndBuffer()
+Rdutil::excludeUniqSizeAndBuffer()
 {
   // sort list on size
   const auto cmp = cmpSize;
@@ -420,7 +420,7 @@ std::size_t
 Rdutil::cleanup()
 {
   const auto size_before = m_list.size();
-  auto it = std::remove_if(m_list.begin(), m_list.end(), [](const Fileinfo& A) {
+  auto it = std::exclude_if(m_list.begin(), m_list.end(), [](const Fileinfo& A) {
     return A.deleteflag();
   });
 
@@ -432,7 +432,7 @@ Rdutil::cleanup()
 }
 #if 0
 std::size_t
-Rdutil::remove_small_files(Fileinfo::filesizetype minsize)
+Rdutil::exclude_small_files(Fileinfo::filesizetype minsize)
 {
   const auto size_before = m_list.size();
   const auto begin = m_list.begin();
@@ -440,9 +440,9 @@ Rdutil::remove_small_files(Fileinfo::filesizetype minsize)
   decltype(m_list.begin()) it;
   if (minsize == 0) {
     it =
-      std::remove_if(begin, end, [](const Fileinfo& A) { return A.isempty(); });
+      std::exclude_if(begin, end, [](const Fileinfo& A) { return A.isempty(); });
   } else {
-    it = std::remove_if(begin, end, [=](const Fileinfo& A) {
+    it = std::exclude_if(begin, end, [=](const Fileinfo& A) {
       return A.is_smaller_than(minsize);
     });
   }

--- a/Rdutil.hh
+++ b/Rdutil.hh
@@ -44,21 +44,21 @@ public:
   /**
    * for each group of identical inodes, only keep the one with the highest
    * rank.
-   * @return number of elements removed
+   * @return number of elements excluded
    */
-  std::size_t removeIdenticalInodes();
+  std::size_t excludeIdenticalInodes();
 
   /**
-   * remove files with unique size from the list.
+   * exclude files with unique size from the list.
    * @return
    */
-  std::size_t removeUniqueSizes();
+  std::size_t excludeUniqueSizes();
 
   /**
-   * remove files with unique combination of size and buffer from the list.
+   * exclude files with unique combination of size and buffer from the list.
    * @return
    */
-  std::size_t removeUniqSizeAndBuffer();
+  std::size_t excludeUniqSizeAndBuffer();
 
   /**
    * Assumes the list is already sorted on size, and all elements with the same
@@ -70,14 +70,14 @@ public:
    */
   void markduplicates();
 
-  /// removes all items from the list, that have the deleteflag set to true.
+  /// excludes all items from the list that have the deleteflag set to true.
   std::size_t cleanup();
 
   /**
-   * Removes items with file size less than minsize
-   * @return the number of removed elements.
+   * Excludes items with file size less than minsize
+   * @return the number of excluded elements.
    */
-  std::size_t remove_small_files(Fileinfo::filesizetype minsize);
+  std::size_t exclude_small_files(Fileinfo::filesizetype minsize);
 
   // read some bytes. note! destroys the order of the list.
   // if lasttype is supplied, it does not reread files if they are shorter

--- a/rdfind.1
+++ b/rdfind.1
@@ -72,8 +72,8 @@ is disabled.
 .BR \-followsymlinks " " \fItrue\fR|\fIfalse\fR
 Follow symlinks. Default is false.
 .TP
-.BR \-removeidentinode " " \fItrue\fR|\fIfalse\fR
-Removes items found which have identical inode and device ID. Default
+.BR \-excludeidentinode " " \fItrue\fR|\fIfalse\fR
+Excludes items found which have identical inode and device ID. Default
 is true.
 .TP
 .BR \-checksum " " \fImd5\fR|\fIsha1\fR|\fIsha256\fR

--- a/testcases/checksum_speedtest.sh
+++ b/testcases/checksum_speedtest.sh
@@ -23,7 +23,7 @@ fi
 
 for checksumtype in md5 sha1 sha256; do
   dbgecho "trying checksum $checksumtype"
-  time $rdfind  -removeidentinode false -checksum $checksumtype speedtest/largefile1 speedtest/largefile2 > rdfind.out
+  time $rdfind  -excludeidentinode false -checksum $checksumtype speedtest/largefile1 speedtest/largefile2 > rdfind.out
 done
 
 dbgecho "all is good in this test!"


### PR DESCRIPTION
The word 'remove' is a synonym of 'delete', and nearly caused me a heart attack when I saw that it was apparently 'removing' the vast proportion of the input files (whereas the message meant that the vast proportion of input files were being removed from the files that are going to be further processed!)

 - I've changed the term from 'remove' to 'exclude'
 - the idea of there being a 'list' of files for consideration is really an internal implementation detail and shouldn't need to be exposed to the user.
 - Even in the README, the word remove was also being used as a synonym for delete: "I can now remove the one I consider a duplicate by hand if I want to"
 - the `-removeidentinode` option has been renamed to `-excludeidentinode`. Have left in support for previous option for backwards compatibility; hopefully I've done that right