### PR TITLE
rdfind: fix missing <limits> include

### DIFF
--- a/rdfind.cc
+++ b/rdfind.cc
@@ -9,6 +9,7 @@
 // std
 #include <algorithm>
 #include <iostream>
+#include <limits>
 #include <string>
 #include <vector>
 


### PR DESCRIPTION
It's required for std::numeric_limits, fixes
compilation with GCC 11.3.