### PR TITLE
fix(scripts): Do not word split file paths that include whitespace

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -8,7 +8,7 @@
 #bail out on error
 set -e
 
-me=$(basename $0)
+me=$(basename "$0")
 
 for prog in aclocal autoheader automake autoconf make; do
    if ! which $prog >/dev/null 2>&1 ; then

--- a/do_clang_format.sh
+++ b/do_clang_format.sh
@@ -14,8 +14,8 @@ if [ ! -x "$CLANGFORMAT" ] ; then
    echo failed finding clangformat
    exit 1
 else
-   echo found clang format: $CLANGFORMAT
+   echo "found clang format: $CLANGFORMAT"
 fi
 
 find . -maxdepth 1 -type f \( -name "*.h" -o -name "*.cpp" -o -name "*.cc" -o -name "*.hh" \) -print0 | \
-   xargs -0 -n1 $CLANGFORMAT -i
+   xargs -0 -n1 "$CLANGFORMAT" -i

--- a/do_quality_checks.sh
+++ b/do_quality_checks.sh
@@ -34,8 +34,8 @@ set -e
 
 export LANG=
 
-rootdir=$(dirname $0)
-me=$(basename $0)
+rootdir=$(dirname "$0")
+me=$(basename "$0")
 
 #flags to configure, for assert.
 ASSERT=


### PR DESCRIPTION
Improve the scripts to make them more resiliant to filepaths with whitespace characters (spaces, tabs, newlines). Before these changes, the shell would exit with a cryptic/mysterious message.