### PR TITLE
prevent recalculations for hardlinked files

### DIFF
--- a/Fileinfo.cc
+++ b/Fileinfo.cc
@@ -22,6 +22,13 @@
 #include "Fileinfo.hh"
 #include "UndoableUnlink.hh"
 
+void
+Fileinfo::copybuffer(const Fileinfo& src) 
+{
+  // copy the buffer from another source (instead of reading/calculating it)
+  std::copy(std::begin(src.m_somebytes), std::end(src.m_somebytes), std::begin(this->m_somebytes));
+}
+
 int
 Fileinfo::fillwithbytes(enum readtobuffermode filltype,
                         enum readtobuffermode lasttype)

--- a/Fileinfo.hh
+++ b/Fileinfo.hh
@@ -149,6 +149,9 @@ public:
 
   std::size_t getbuffersize() const { return m_somebytes.size(); }
 
+  // copy the buffer from another source instead of (reading/calculating it)
+  void copybuffer(const Fileinfo& src);
+
   /// returns true if file is a regular file. call readfileinfo first!
   bool isRegularFile() const { return m_info.is_file; }
 


### PR DESCRIPTION
In order to prevent the caveat surrounding groups of hardlinked files, one should run rdfind with '-removeidentinode false'.
However as a user of the ”hardlinks and rsync”-type of backup, this means that there are many files that are already hardlinked. For each of these hardlinked files expensive disk reads and very expensive checksum calculations are needed.
This patch verifies before such a disk access if the file is a hardlink to the previous file and if so copies the calculation or disk read result from that file.

One special case in this code is that may be regarded as an error is for the first file. The first file is compared to the last file (which has no valid m_somebytes yet). However, if the first file is hardlinked with the last file, it must be so that ALL files in the list are hardlinked to each other, so all files will have m_somebytes equal to an array filled with '\0'. The result will still be that rdfind will say all these files are 'the same', which is indeed the end result we wanted.