### PR TITLE
fix typos

### DIFF
--- a/Dirlist.cc
+++ b/Dirlist.cc
@@ -54,7 +54,7 @@ Dirlist::walk(const std::string& dir, const int recursionlevel)
     if (0 == strcmp(".", dp->d_name) || 0 == strcmp("..", dp->d_name)) {
       continue;
     }
-    // investigate what kind of file it is, dont follow any
+    // investigate what kind of file it is, don't follow any
     // symlinks when doing this (lstat instead of stat).
     struct stat info;
     const int statval =
@@ -130,7 +130,7 @@ Dirlist::handlepossiblefile(const std::string& possiblefile, int recursionlevel)
   RDDEBUG("split filename is path=" << path.c_str() << " filename="
                                     << filename.c_str() << std::endl);
 
-  // investigate what kind of file it is, dont follow symlink
+  // investigate what kind of file it is, don't follow symlink
   int statval = 0;
   struct stat info;
   do {

--- a/do_quality_checks.sh
+++ b/do_quality_checks.sh
@@ -329,7 +329,7 @@ run_with_sanitizer "-fsanitize=undefined -O3"
 run_with_sanitizer "-fsanitize=address -O0"
 
 #build and test with all flags from debian, if available. this increases
-#the likelilihood rdfind will build when creating a deb package.
+#the likelihood rdfind will build when creating a deb package.
 ASSERT=""
 run_with_debian_buildflags
 


### PR DESCRIPTION
```
$ sed -i "s/dont/don't/g" rdfind/Dirlist.cc
$ sed -i "s/likelilihood/likelihood/g" rdfind/do_quality_checks.sh
$ 
```