### PR TITLE
Fix en-dashes in man page

### DIFF
--- a/rdfind.1
+++ b/rdfind.1
@@ -7,7 +7,7 @@
 .SH NAME
 rdfind \- finds duplicate files
 .SH SYNOPSIS
-.B rdfind [ options ] 
+.B rdfind [ options ]
 .I directory1 | file1
 .B [
 .I directory2 | file2
@@ -16,7 +16,7 @@ rdfind \- finds duplicate files
 .B rdfind
 finds duplicate files across and/or within several directories. It calculates
 checksum only if necessary.
-rdfind runs in O(Nlog(N)) time with N being the number of files. 
+rdfind runs in O(Nlog(N)) time with N being the number of files.
 
 If two (or more) equal files are found, the program decides which of
 them is the original and the rest are considered duplicates. This
@@ -24,22 +24,22 @@ is done by ranking the files to each other and deciding which has the
 highest rank. See section RANKING for details.
 
 By default, no action is taken besides creating a file with the
-detected files and showing the possible amount of saved space. 
+detected files and showing the possible amount of saved space.
 
 If you need better control over the ranking than given, you can use
 some preprocessor which sorts the file names in desired order and then
 run the program using xargs. See examples below for how to use find
 and xargs in conjunction with rdfind.
 
-To include files or directories that have names starting with -, use 
-rdfind ./- to not confuse them with options.
+To include files or directories that have names starting with \-, use
+rdfind ./\- to not confuse them with options.
 
 .SH RANKING
 Given two or more equal files, the one with the highest rank is
 selected to be the original and the rest are duplicates. The rules of
 ranking are given below, where the rules are executed from start until
 an original has been found. Given two files A and B which have equal
-size and content, the ranking is as follows: 
+size and content, the ranking is as follows:
 
 If A was found while scanning an input argument earlier than B, A
 is higher ranked.
@@ -50,7 +50,7 @@ If A was found at a directory depth lower than B, A is higher ranked
 if A and B are found during scanning of the same input argument and share
 the same directory depth, the one that ranks highest depends on if
 deterministic operation is enabled. This is on by default, see option
-\fB-deterministic\fR). If enabled, which one ranks highest is
+\fB\-deterministic\fR). If enabled, which one ranks highest is
 unspecified but deterministic. If disabled, the one that was reported
 first from the file system is highest ranked.
 
@@ -59,7 +59,7 @@ Searching options etc:
 .TP
 .BR \-ignoreempty " " \fItrue\fR|\fIfalse\fR
 Ignore empty files. Setting this to true (the default) is equivalent to
--minsize 1, false is equivalent to -minsize 0.
+\-minsize 1, false is equivalent to \-minsize 0.
 .TP
 .BR \-minsize " "\fIN\fR
 Ignores files with less than N bytes. Default is 1, meaning empty files
@@ -96,7 +96,7 @@ Replace duplicate files with hard links. Default is false.
 .BR \-makeresultsfile " " \fItrue\fR|\fIfalse\fR
 Make a results file in the current directory. Default is true. If the
 file exists, it is overwritten. This does not affect whether items are
-deleted. See -dryrun for how to disable deletions.
+deleted. See \-dryrun for how to disable deletions.
 .TP
 .BR \-outputname " " \fIname\fR
 Make the results file name to be "name" instead of the default
@@ -110,7 +110,7 @@ General options:
 .BR \-sleep " " \fIX\fRms
 Sleeps X milliseconds between reading each file, to reduce
 load. Default is 0 (no sleep). Note that only a few values are
-supported at present: 0,1-5,10,25,50,100 milliseconds. 
+supported at present: 0,1-5,10,25,50,100 milliseconds.
 .TP
 .BR \-n ", " \-dryrun " " \fItrue\fR|\fIfalse\fR
 Displays what should have been done, don't actually delete or link
@@ -127,10 +127,10 @@ Search for duplicate files in the home directory and a backup directory:
 .B rdfind ~ /mnt/backup
 .TP
 Delete duplicates in a backup directory:
-.B rdfind -deleteduplicates true /mnt/backup
+.B rdfind \-deleteduplicates true /mnt/backup
 .TP
 Search for duplicate files in directories called foo:
-.B find . -type d -name foo -print0 |xargs -0 rdfind
+.B find . \-type d \-name foo \-print0 |xargs \-0 rdfind
 .SH FILES
 .I results.txt
 (the default name is results.txt and can be changed with option outputname,
@@ -146,7 +146,7 @@ DUPTYPE_WITHIN_SAME_TREE files in the same tree (found when processing
 the directory in the same input argument as the original)
 
 DUPTYPE_OUTSIDE_TREE the file is found during processing another input
-argument than the original. 
+argument than the original.
 .SH ENVIRONMENT
 .SH DIAGNOSTICS
 .SH EXIT VALUES


### PR DESCRIPTION
Groff will change a bare "-" into a Unicode en-dash unless prefixed with "\\"

Changed only where a literal ASCII hyphen is intended (code, option flags).

Also, strip trailing whitespace (shitespace) that Groff already condenses.