### PR TITLE
add option to disable checksum verification

### DIFF
--- a/rdfind.cc
+++ b/rdfind.cc
@@ -61,7 +61,7 @@ usage()
     << " -followsymlinks    true |(false) follow symlinks\n"
     << " -removeidentinode (true)| false  ignore files with nonunique "
        "device and inode\n"
-    << " -checksum           md5 |(sha1)| sha256 | sha512\n"
+    << " -checksum           none | md5 |(sha1)| sha256 | sha512 \n"
     << "                                  checksum type\n"
     << " -deterministic    (true)| false  makes results independent of order\n"
     << "                                  from listing the filesystem\n"
@@ -107,6 +107,7 @@ struct Options
   bool usesha1 = false;      // use sha1 checksum to check for similarity
   bool usesha256 = false;    // use sha256 checksum to check for similarity
   bool usesha512 = false;    // use sha512 checksum to check for similarity
+  bool usenone = false;      // skip the checksum step entirely and only rely on name and file size
   bool deterministic = true; // be independent of filesystem order
   long nsecsleep = 0; // number of nanoseconds to sleep between each file read.
   std::string resultsfile = "results.txt"; // results file name.
@@ -169,7 +170,9 @@ parseOptions(Parser& parser)
     } else if (parser.try_parse_bool("-deterministic")) {
       o.deterministic = parser.get_parsed_bool();
     } else if (parser.try_parse_string("-checksum")) {
-      if (parser.parsed_string_is("md5")) {
+      if (parser.parsed_string_is("none")) {
+        o.usenone = true;
+      } else if (parser.parsed_string_is("md5")) {
         o.usemd5 = true;
       } else if (parser.parsed_string_is("sha1")) {
         o.usesha1 = true;
@@ -178,7 +181,7 @@ parseOptions(Parser& parser)
       } else if (parser.parsed_string_is("sha512")) {
         o.usesha512 = true;
       } else {
-        std::cerr << "expected md5/sha1/sha256/sha512, not \""
+        std::cerr << "expected none/md5/sha1/sha256/sha512, not \""
                   << parser.get_parsed_string() << "\"\n";
         std::exit(EXIT_FAILURE);
       }
@@ -239,8 +242,8 @@ parseOptions(Parser& parser)
 
   // done with parsing of options. remaining arguments are files and dirs.
 
-  // decide what checksum to use - if no checksum is set, force sha1!
-  if (!o.usemd5 && !o.usesha1 && !o.usesha256 && !o.usesha512) {
+  // decide what checksum to use - if no checksum is option is specified, default to sha1!
+  if (!o.usenone && !o.usemd5 && !o.usesha1 && !o.usesha256 && !o.usesha512) {
     o.usesha1 = true;
   }
   return o;


### PR DESCRIPTION
closes https://github.com/pauldreik/rdfind/issues/118

I saw that there was a previous PR from a few years ago addressing this that was never merged. This is an updated solution based off of the top of main, and is a simpler implementation with fewer changes.

Tested on my Debian 12 home NAS server and it behaves as expected.

The drive I was checking is over 16TiB of usable space with over 500k files. It took overnight to run _without_ doing a checksum (only checking names/sizes and then following up with first/last bytes). If I had checksumming on, it would still be running, and for days most likely. The output without the checksum was still very useful as I'll explain below.

----

To the maintainer(s), I think there is a real use case for this:

In my example, I have a NAS with dozens of TB of storage. I have a lot of files that are significantly large (dozens to hundreds of GB). I've been doing some file reorganization and my goal is just to get a short list of files that might be duplicates that I can then process later.

In my case, if these large files have the same name and size and first/last bytes, I can be basically 100% sure they're the same file. It would take exponentially longer to checksum every file at discovery time only to find out what I already know...they're the same.

Later if needed I can manually checksum files in the results list, or even do something like test/checksum random byte ranges in the files rather than checksumming the whole thing to save a ton of time, but in my case (and I assume others' as well) I already know they're the same so even that isn't needed.

To be clear, I think the default should stay the same (or maybe even go up to sha256/512), but at least having the option to disable checksumming can be very useful and the change is only a few lines.