### PR TITLE
operate on all detected hardlinks

### DIFF
--- a/Fileinfo.hh
+++ b/Fileinfo.hh
@@ -10,6 +10,7 @@
 #include <array>
 #include <cstdint>
 #include <string>
+#include <vector>
 
 // os specific headers
 #include <sys/types.h> //for off_t and others.
@@ -127,6 +128,12 @@ public:
   // gets the filename
   const std::string& name() const { return m_filename; }
 
+  // gets the filename
+  const std::vector<std::string>& aliases() const { return m_aliases; }
+
+  // adds a filename alias
+  void add_alias(std::string n) { m_aliases.push_back(n); }
+
   // gets the command line index this item was found at
   int get_cmdline_index() const { return m_cmdline_index; }
 
@@ -173,6 +180,9 @@ private:
 
   // to be deleted or not
   bool m_delete;
+
+  // list of hardlinks
+  std::vector<std::string> m_aliases;
 
   duptype m_duptype;
 


### PR DESCRIPTION
fixes pauldreik/rdfind#109

description of issue: secondary files with identical dev/inode pairs are dropped in favor of the highest ranking file within a group of identicals and thus removed from consideration early on in the selection process.

description of changes: keep a list of path references to identical dev/inodes as std::vector m_aliases in Fileinfo; apply all operations (print, delete, symlink, hardlink) to aliases as well.

considerations: 
- might further unify delete, symlink and hardlink operations into one worker function (alike transactional_operation) with callback to desired operation.
- a command line option for the modified behaviour appears unnecessary because pauldreik/rdfind#109 feels more like a bug rather than a feature request; I cannot think of a situation where the secondary references should not be handled in the same way as the highest ranking one  (unless further criteria for selection are added).
- this appears to address the same issue as pauldreik/rdfind#68 albeit with a different approach.