### PR TITLE
fix minor bug in digest length check

### DIFF
--- a/Fileinfo.cc
+++ b/Fileinfo.cc
@@ -88,11 +88,9 @@ Fileinfo::fillwithbytes(enum readtobuffermode filltype,
     }
 
     // store the result of the checksum calculation in somebytes
-    int digestlength = chk.getDigestLength();
-    if (digestlength <= 0 ||
-        digestlength >= static_cast<int>(m_somebytes.size())) {
-      std::cerr << "wrong answer from getDigestLength! FIXME" << std::endl;
-    }
+    assert(chk.getDigestLength() > 0);
+    assert(static_cast<std::size_t>(chk.getDigestLength()) <=
+           m_somebytes.size());
     if (chk.printToBuffer(m_somebytes.data(), m_somebytes.size())) {
       std::cerr << "failed writing digest to buffer!!" << std::endl;
     }

--- a/Fileinfo.cc
+++ b/Fileinfo.cc
@@ -41,7 +41,7 @@ Fileinfo::fillwithbytes(enum readtobuffermode filltype,
   m_somebytes.fill('\0');
 
   std::fstream f1;
-  f1.open(m_filename.c_str(), std::ios_base::in);
+  f1.open(m_filename, std::ios_base::in);
   if (!f1.is_open()) {
     std::cerr << "fillwithbytes.cc: Could not open file \"" << m_filename
               << "\"" << std::endl;

--- a/Fileinfo.hh
+++ b/Fileinfo.hh
@@ -194,7 +194,7 @@ private:
    */
   std::int64_t m_identity;
 
-  static const int SomeByteSize = 64;
+  static constexpr int SomeByteSize = 64;
 
   /// a buffer that will be filled with some bytes of the file or a hash
   std::array<char, SomeByteSize> m_somebytes;

--- a/testcases/checksum_options.sh
+++ b/testcases/checksum_options.sh
@@ -7,16 +7,37 @@ set -e
 
 
 
+allchecksumtypes="md5 sha1 sha256 sha512"
 
 
-for checksumtype in md5 sha1 sha256 sha512; do
+for checksumtype in $allchecksumtypes; do
    reset_teststate
-   dbgecho "trying checksum $checksumtype"
+   dbgecho "trying checksum $checksumtype with small files"
    echo checksumtest >a
    echo checksumtest >b
    $rdfind  -checksum $checksumtype -deleteduplicates true a b
    [ -e a ]
    [ ! -e b ]
+done
+
+for checksumtype in $allchecksumtypes; do
+   reset_teststate
+   dbgecho "trying checksum $checksumtype with large files"
+   head -c 1000000 /dev/zero >a
+   head -c 1000000 /dev/zero >b
+   $rdfind  -checksum $checksumtype -deleteduplicates true a b
+   [ -e a ]
+   [ ! -e b ]
+done
+
+for checksumtype in $allchecksumtypes; do
+   reset_teststate
+   dbgecho "trying checksum $checksumtype with large files that differ only in the middle"
+   ( head -c 1000000 /dev/zero; echo =====a=====; head -c 1000000 /dev/zero) >a
+   ( head -c 1000000 /dev/zero; echo =====b=====; head -c 1000000 /dev/zero) >b
+   $rdfind  -checksum $checksumtype -deleteduplicates true a b
+   [ -e a ]
+   [ -e b ]
 done
 
 dbgecho "all is good in this test!"


### PR DESCRIPTION
thanks to @trollkarlen (see https://github.com/pauldreik/rdfind/pull/167) for finding this.

the consequences are mostly annoying: if run with SHA512 as checksum type, a printout is shown: `wrong answer from getDigestLength! FIXME`

this tells me almost noone uses the SHA512 option, at least not to the extent of getting annoyed and filing an issue.

I made the check into an assert and extended the unit test to trigger the interesting part of the code.
