### PR TITLE
add buffersize argument to rdfind

### DIFF
--- a/Fileinfo.cc
+++ b/Fileinfo.cc
@@ -12,6 +12,7 @@
 #include <cstring>  //for strerror
 #include <fstream>  //for file reading
 #include <iostream> //for cout etc
+#include <vector>
 
 // os
 #include <sys/stat.h> //for file info
@@ -24,7 +25,8 @@
 
 int
 Fileinfo::fillwithbytes(enum readtobuffermode filltype,
-                        enum readtobuffermode lasttype)
+                        enum readtobuffermode lasttype,
+                        const long buffersize)
 {
 
   // Decide if we are going to read from file or not.
@@ -80,11 +82,12 @@ Fileinfo::fillwithbytes(enum readtobuffermode filltype,
   if (checksumtype != Checksum::checksumtypes::NOTSET) {
     Checksum chk(checksumtype);
 
-    char buffer[4096];
+    std::vector<char> buffer(buffersize);
+
     while (f1) {
-      f1.read(buffer, sizeof(buffer));
+      f1.read(buffer.data(), buffer.size());
       // gcount is never negative, the cast is safe.
-      chk.update(static_cast<std::size_t>(f1.gcount()), buffer);
+      chk.update(static_cast<std::size_t>(f1.gcount()), buffer.data());
     }
 
     // store the result of the checksum calculation in somebytes

--- a/Fileinfo.hh
+++ b/Fileinfo.hh
@@ -135,10 +135,12 @@ public:
    * is shorter than the length of the bytes field.
    * @param filltype
    * @param lasttype
+   * @param buffersize
    * @return zero on success
    */
   int fillwithbytes(enum readtobuffermode filltype,
-                    enum readtobuffermode lasttype);
+                    enum readtobuffermode lasttype,
+                    const long buffersize);
 
   /// get a pointer to the bytes read from the file
   const char* getbyteptr() const { return m_somebytes.data(); }

--- a/Makefile.am
+++ b/Makefile.am
@@ -18,7 +18,8 @@ TESTS=testcases/largefilesupport.sh \
       testcases/verify_deterministic_operation.sh \
       testcases/checksum_options.sh \
       testcases/md5collisions.sh \
-      testcases/sha1collisions.sh
+      testcases/sha1collisions.sh \
+      testcases/checksum_buffersize.sh
 
 AUXFILES=testcases/common_funcs.sh \
          testcases/md5collisions/letter_of_rec.ps \

--- a/Rdutil.cc
+++ b/Rdutil.cc
@@ -542,7 +542,8 @@ Rdutil::saveablespace(std::ostream& out) const
 int
 Rdutil::fillwithbytes(enum Fileinfo::readtobuffermode type,
                       enum Fileinfo::readtobuffermode lasttype,
-                      const long nsecsleep)
+                      const long nsecsleep,
+                      const long buffersize)
 {
   // first sort on inode (to read efficiently from the hard drive)
   sortOnDeviceAndInode();
@@ -550,7 +551,7 @@ Rdutil::fillwithbytes(enum Fileinfo::readtobuffermode type,
   const auto duration = std::chrono::nanoseconds{ nsecsleep };
 
   for (auto& elem : m_list) {
-    elem.fillwithbytes(type, lasttype);
+    elem.fillwithbytes(type, lasttype, buffersize);
     if (nsecsleep > 0) {
       std::this_thread::sleep_for(duration);
     }

--- a/Rdutil.hh
+++ b/Rdutil.hh
@@ -90,7 +90,8 @@ public:
   int fillwithbytes(enum Fileinfo::readtobuffermode type,
                     enum Fileinfo::readtobuffermode lasttype =
                       Fileinfo::readtobuffermode::NOT_DEFINED,
-                    long nsecsleep = 0);
+                    long nsecsleep = 0,
+                    const long buffersize = 4096);
 
   /// make symlinks of duplicates.
   std::size_t makesymlinks(bool dryrun) const;

--- a/rdfind.1
+++ b/rdfind.1
@@ -80,6 +80,11 @@ is true.
 What type of checksum to be used: md5, sha1, sha256 or sha512. The default is
 sha1 since version 1.4.0.
 .TP
+.BR \-buffersize " " \fIN\fR " " (N=4096,0<N<1000KB)
+Chunksize when calculating the checksum
+for files, smaller or bigger can improve performance
+dependent on filesystem and checksum algorithm.
+.TP
 .BR \-deterministic " " \fItrue\fR|\fIfalse\fR
 If set (the default), sort files of equal rank in an unspecified but
 deterministic order. This makes the behaviour independent of in which

--- a/rdfind.cc
+++ b/rdfind.cc
@@ -41,7 +41,7 @@ static void
 usage()
 {
   std::cout
-    << "Usage: " << "rdfind [options] FILE ...\n"
+    << "Usage: rdfind [options] FILE ...\n"
     << '\n'
     << "Finds duplicate files recursively in the given FILEs (directories),\n"
     << "and takes appropriate action (by default, nothing).\n"
@@ -65,6 +65,13 @@ usage()
        "device and inode\n"
     << " -checksum           md5 |(sha1)| sha256 | sha512\n"
     << "                                  checksum type\n"
+    << " -buffersize N     (N=4096,0<N<1000KB)\n"
+       "                                  Chunksize when calculating the "
+       "checksum\n"
+       "                                  for files, smaller or bigger can "
+       "improve performance\n"
+       "                                  dependent on filesystem and checksum "
+       "algorithm.\n"
     << " -deterministic    (true)| false  makes results independent of order\n"
     << "                                  from listing the filesystem\n"
     << " -makesymlinks      true |(false) replace duplicate files with "
@@ -75,7 +82,7 @@ usage()
     << " -outputname  name  sets the results file name to \"name\" "
        "(default results.txt)\n"
     << " -deleteduplicates  true |(false) delete duplicate files\n"
-    << " -sleep              Xms          sleep for X milliseconds between "
+    << " -sleep             Xms          sleep for X milliseconds between "
        "file reads.\n"
     << "                                  Default is 0. Only a few values\n"
     << "                                  are supported; 0,1-5,10,25,50,100\n"
@@ -105,11 +112,12 @@ struct Options
   bool followsymlinks = false;        // follow symlinks
   bool dryrun = false;                // only dryrun, don't destroy anything
   bool remove_identical_inode = true; // remove files with identical inodes
-  bool usemd5 = false;       // use md5 checksum to check for similarity
-  bool usesha1 = false;      // use sha1 checksum to check for similarity
-  bool usesha256 = false;    // use sha256 checksum to check for similarity
-  bool usesha512 = false;    // use sha512 checksum to check for similarity
-  bool deterministic = true; // be independent of filesystem order
+  bool usemd5 = false;           // use md5 checksum to check for similarity
+  bool usesha1 = false;          // use sha1 checksum to check for similarity
+  bool usesha256 = false;        // use sha256 checksum to check for similarity
+  bool usesha512 = false;        // use sha512 checksum to check for similarity
+  std::size_t buffersize = 4096; // chunksize to use when reading files
+  bool deterministic = true;     // be independent of filesystem order
   long nsecsleep = 0; // number of nanoseconds to sleep between each file read.
   std::string resultsfile = "results.txt"; // results file name.
 };
@@ -184,6 +192,16 @@ parseOptions(Parser& parser)
                   << parser.get_parsed_string() << "\"\n";
         std::exit(EXIT_FAILURE);
       }
+    } else if (parser.try_parse_string("-buffersize")) {
+      const long buffersize = std::stoll(parser.get_parsed_string());
+      if (buffersize <= 0) {
+        std::cerr << "negative or 0 value of buffersize not allowed\n";
+        std::exit(EXIT_FAILURE);
+      } else if (buffersize > 1000 * 1024) {
+        std::cerr << "maximum 1000KB value of buffersize not allowed";
+        std::exit(EXIT_FAILURE);
+      }
+      o.buffersize = buffersize;
     } else if (parser.try_parse_string("-sleep")) {
       const auto nextarg = std::string(parser.get_parsed_string());
       if (nextarg == "1ms") {
@@ -383,7 +401,7 @@ main(int narg, const char* argv[])
               << it->second << ": " << std::flush;
 
     // read bytes (destroys the sorting, for disk reading efficiency)
-    gswd.fillwithbytes(it[0].first, it[-1].first, o.nsecsleep);
+    gswd.fillwithbytes(it[0].first, it[-1].first, o.nsecsleep, o.buffersize);
 
     // remove non-duplicates
     std::cout << "removed " << gswd.removeUniqSizeAndBuffer()

--- a/testcases/checksum_buffersize.sh
+++ b/testcases/checksum_buffersize.sh
@@ -1,0 +1,45 @@
+#!/bin/sh
+# Test that selection of buffersizes works as expected.
+
+set -e
+. "$(dirname "$0")/common_funcs.sh"
+
+reset_teststate
+
+TEST_DIR=buffersizes_speedtest
+mkdir -p "$TEST_DIR"
+
+make_test_files() {
+    dbgecho "creating test files in $TEST_DIR"
+    head -c 1000000 /dev/zero >"$TEST_DIR/a"
+    cp "$TEST_DIR/a" "$TEST_DIR/b"
+    cp "$TEST_DIR/a" "$TEST_DIR/c"
+    cp "$TEST_DIR/a" "$TEST_DIR/d"
+    cp "$TEST_DIR/a" "$TEST_DIR/e"
+}
+
+dbgecho "check so all buffersizes behave the same"
+
+# disables only run once shellscheck
+# shellcheck disable=SC2043
+for checksumtype in sha256; do
+    i=1
+    while :; do
+        if [ $i -gt 128 ]; then
+            break
+        fi
+        i="$((i*2))"
+        make_test_files
+        dbgecho "testing buffersize $((i*1024))"
+        dbgecho "testing $checksumtype"
+        # Fix this properly by making rdfind to array and use "${rdfind[@]}"
+        # this requires bash not sh
+        # shellcheck disable=SC2086
+        $rdfind -buffersize $((i*1024)) -checksum "$checksumtype" -deleteduplicates true "$TEST_DIR" >/dev/null
+        [ -e "$TEST_DIR/a" ]
+        [ ! -e "$TEST_DIR/b" ]
+        [ ! -e "$TEST_DIR/c" ]
+        [ ! -e "$TEST_DIR/d" ]
+        [ ! -e "$TEST_DIR/e" ]
+    done
+done

--- a/testcases/checksum_buffersize_speedtest.sh
+++ b/testcases/checksum_buffersize_speedtest.sh
@@ -1,0 +1,45 @@
+#!/bin/sh
+# Performance test for checksumming with diffrent buffersizes. Not meant
+# to be run for regular testing.
+
+set -e
+. "$(dirname "$0")/common_funcs.sh"
+
+reset_teststate
+
+TEST_DIR=buffersizes_speedtest
+mkdir -p "$TEST_DIR"
+
+make_test_files() {
+    dbgecho "creating test files in $TEST_DIR"
+    head -c $((1024*1024*500)) /dev/zero >"$TEST_DIR/a"
+    cp "$TEST_DIR/a" "$TEST_DIR/b"
+    cp "$TEST_DIR/a" "$TEST_DIR/c"
+    cp "$TEST_DIR/a" "$TEST_DIR/d"
+    cp "$TEST_DIR/a" "$TEST_DIR/e"
+}
+
+dbgecho "run speed test for all shecksums and buffersizes"
+
+make_test_files
+
+for checksumtype in md5 sha1 sha256 sha512; do
+    i=1
+    while :; do
+        if [ $i -gt 128 ]; then
+            break
+        fi
+        i="$((i*2))"
+        dbgecho "testing buffersize $((i*1024))"
+        dbgecho "testing $checksumtype"
+        # Fix this properly by making rdfind to array and use "${rdfind[@]}"
+        # this requires bash not sh
+        # shellcheck disable=SC2086
+        time $rdfind -buffersize $((i*1024)) -checksum "$checksumtype" -dryrun true -deleteduplicates true "$TEST_DIR" >/dev/null
+        dbgecho "testing $checksumtype memusage"
+        # shellcheck disable=SC2086
+        /usr/bin/time -f '%M kB' $rdfind -buffersize $((i*1024)) -checksum "$checksumtype" -dryrun true -deleteduplicates true "$TEST_DIR" >/dev/null
+    done
+done
+
+


### PR DESCRIPTION
add the argument to change buffer size of checksum calculation, may increase speed on some checksum algorithms and disk types.