### PR TITLE
add xxHash checksum (based on of trollkarlen's work)

### DIFF
--- a/.github/workflows/ubuntu-default-with-xxhash.yml
+++ b/.github/workflows/ubuntu-default-with-xxhash.yml
@@ -1,0 +1,39 @@
+---
+name: ubuntu default build with xxhash
+
+"on":
+  push:
+    branches:
+      - main
+      - devel
+  pull_request:
+
+jobs:
+  build:
+    name: Test on ${{ matrix.os }} with xxhash
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-22.04, ubuntu-24.04]
+
+    steps:
+      - name: checkout
+        uses: actions/checkout@v4
+      - name: install packages
+        run: sudo apt install build-essential nettle-dev libxxhash-dev
+      - name: bootstrap
+        run: ./bootstrap.sh
+      - name: configure
+        run: ./configure --with-xxhash --enable-warnings CXXFLAGS=-std=c++17
+      - name: make
+        run: make
+      - name: make check
+        run: WITH_XXHASH=1 make check
+      - name: WITH_XXHASH=1 make distcheck
+        run: make distcheck CXXFLAGS=-std=c++17
+      - name: store the logs as an artifact
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: log-artifacts-${{ matrix.os }}
+          path: '**/*.log'

--- a/Checksum.hh
+++ b/Checksum.hh
@@ -13,6 +13,12 @@
 #include <nettle/sha1.h>
 #include <nettle/sha2.h>
 
+#include "config.h"
+
+#ifdef HAVE_LIBXXHASH
+#include <xxhash.h>
+#endif
+
 /**
  * class for checksum calculation
  */
@@ -26,7 +32,8 @@ public:
     MD5,
     SHA1,
     SHA256,
-    SHA512
+    SHA512,
+    XXH128
   };
 
   explicit Checksum(checksumtypes type);
@@ -56,6 +63,9 @@ private:
     sha256_ctx sha256;
     sha512_ctx sha512;
     md5_ctx md5;
+#ifdef HAVE_LIBXXHASH
+    XXH3_state_t* xxh128;
+#endif
   } m_state;
 };
 

--- a/Fileinfo.cc
+++ b/Fileinfo.cc
@@ -73,6 +73,9 @@ Fileinfo::fillwithbytes(enum readtobuffermode filltype,
     case readtobuffermode::CREATE_SHA512_CHECKSUM:
       checksumtype = Checksum::checksumtypes::SHA512;
       break;
+    case readtobuffermode::CREATE_XXH128_CHECKSUM:
+      checksumtype = Checksum::checksumtypes::XXH128;
+      break;
     default:
       std::cerr << "does not know how to do that filltype:"
                 << static_cast<long>(filltype) << std::endl;

--- a/Fileinfo.hh
+++ b/Fileinfo.hh
@@ -49,6 +49,7 @@ public:
     CREATE_SHA1_CHECKSUM,
     CREATE_SHA256_CHECKSUM,
     CREATE_SHA512_CHECKSUM,
+    CREATE_XXH128_CHECKSUM,
   };
 
   // type of duplicate

--- a/Makefile.am
+++ b/Makefile.am
@@ -6,6 +6,7 @@ bin_PROGRAMS = rdfind
 rdfind_SOURCES = rdfind.cc Checksum.cc  Dirlist.cc  Fileinfo.cc  Rdutil.cc \
                  EasyRandom.cc UndoableUnlink.cc CmdlineParser.cc
 
+LDADD = @LIBXXHASH@
 #these are the test scripts to execute - I do not know how to glob here,
 #feedback welcome.
 TESTS=testcases/largefilesupport.sh \

--- a/configure.ac
+++ b/configure.ac
@@ -54,6 +54,40 @@ AC_CHECK_LIB(nettle,nettle_pbkdf2_hmac_sha256,,[AC_MSG_ERROR([
  and try again.
 ])])
 
+dnl xxh hashing is optional:
+dnl   --with-xxhash requires it
+dnl   --without-xxhash does not use it
+dnl   not saying anything enables it if it can be found
+AC_ARG_WITH([xxhash],
+            [AS_HELP_STRING([--with-xxhash],
+              [support xxhash @<:@default=check@:>@])],
+            [],
+            [with_xxhash=check])
+
+          LIBXXHASH=
+          AS_IF([test "x$with_xxhash" != xno],
+            [AC_CHECK_LIB([xxhash], [XXH3_128bits],
+              [AC_SUBST([LIBXXHASH], ["-lxxhash"])
+               AC_DEFINE([HAVE_LIBXXHASH], [1],
+                         [Define if you have libxxhash])
+              ],
+              [if test "x$with_xxhash" != xcheck; then
+                 AC_MSG_FAILURE([
+                   --with-xxhash was given, but test for xxhash failed.
+                   Please install xxhash first. If you have already done so and get this error message
+                   anyway, it may be installed somewhere else, maybe because you
+                   don't have root access. Pass CPPFLAGS=-I/your/path/to/xxhash to configure
+                   and try again. The path should be so that \#include "xxhash.h" works.
+                   On Debian-ish systems, use "apt-get install libxxhash-dev" to get a system
+                   wide xxhash install.
+                   On RedHat-ish systems, use "dnf install xxhash-devel" to get a system
+                   wide xxhash install.
+                   If you have xxhash somewhere else, maybe because you don't have root
+                   access, pass LDFLAGS=-L/your/path/to/xxhash to configure and try again.
+                 ])
+               fi
+              ],)])
+
 dnl test for some specific functions
 AC_CHECK_FUNC(stat,,AC_MSG_ERROR(oops! no stat ?!?))
 

--- a/inofficial_cmake/CMakeLists.txt
+++ b/inofficial_cmake/CMakeLists.txt
@@ -9,6 +9,15 @@ project(rdfind VERSION "${PROJECT_VERSION}")
 find_package(PkgConfig)
 pkg_check_modules(nettle REQUIRED nettle)
 
+pkg_check_modules(xxhash IMPORTED_TARGET libxxhash)
+
+if(xxhash_FOUND)
+    set(HAVE_LIBXXHASH 1)
+else()
+    set(HAVE_LIBXXHASH 0)
+endif()
+
+
 configure_file(config.h.in config.h @ONLY)
 
 add_executable(rdfind
@@ -33,5 +42,8 @@ target_include_directories(rdfind PRIVATE ..)
 
 target_compile_features(rdfind PRIVATE cxx_std_17)
 target_link_libraries(rdfind nettle)
+if(xxhash_FOUND)
+target_link_libraries(rdfind PkgConfig::xxhash)
+endif()
 target_compile_options(rdfind PRIVATE -Wall -Wextra -Wpedantic)
 

--- a/inofficial_cmake/config.h.in
+++ b/inofficial_cmake/config.h.in
@@ -1,4 +1,5 @@
 #cmakedefine RDFIND_VERSION "@RDFIND_VERSION@"
 #cmakedefine FOO_ENABLE
 #cmakedefine FOO_STRING "@FOO_STRING@"
+#cmakedefine HAVE_LIBXXHASH @HAVE_LIBXXHASH@
 #define VERSION "@RDFIND_VERSION@"

--- a/rdfind.1
+++ b/rdfind.1
@@ -76,9 +76,11 @@ Follow symlinks. Default is false.
 Removes items found which have identical inode and device ID. Default
 is true.
 .TP
-.BR \-checksum " " \fImd5\fR|\fIsha1\fR|\fIsha256\fR|\fIsha512\fR
-What type of checksum to be used: md5, sha1, sha256 or sha512. The default is
-sha1 since version 1.4.0.
+.BR \-checksum " " \fImd5\fR|\fIsha1\fR|\fIsha256\fR|\fIsha512|\fIxxh128\fR
+What type of checksum to be used: md5, sha1, sha256, sha512 or xxh128. The default is
+sha1 since version 1.4.0. xxh128 is a very fast checksum, but not of cryptographic
+quality. xxh support is optional and requires that rdfind was configured with
+--with-xxhash. In case xxh is used but there is no support, an error is returned.
 .TP
 .BR \-buffersize " " \fIN\fR
 Chunksize in bytes when calculating the checksum

--- a/testcases/checksum_buffersize_speedtest.sh
+++ b/testcases/checksum_buffersize_speedtest.sh
@@ -28,7 +28,7 @@ make_test_files
 
 cat /dev/null >"$TEST_DIR/results.tsv"
 for filesize in big small; do
-for checksumtype in md5 sha1; do
+for checksumtype in sha1 xxh128; do
     i=1
     while :; do
         if [ $i -gt 4096 ]; then

--- a/testcases/checksum_options.sh
+++ b/testcases/checksum_options.sh
@@ -1,14 +1,8 @@
 #!/bin/sh
 # Test that selection of checksum works as expected.
 
-
 set -e
 . "$(dirname "$0")/common_funcs.sh"
-
-
-
-allchecksumtypes="md5 sha1 sha256 sha512"
-
 
 for checksumtype in $allchecksumtypes; do
    reset_teststate

--- a/testcases/checksum_speedtest.sh
+++ b/testcases/checksum_speedtest.sh
@@ -8,7 +8,6 @@ set -e
 
 reset_teststate
 
-
 if [ ! -d speedtest ] ; then
    mkdir -p speedtest
 fi
@@ -21,9 +20,9 @@ if [ ! -e speedtest/largefile1 ] ; then
 fi
 
 
-for checksumtype in md5 sha1 sha256; do
+for checksumtype in $allchecksumtypes; do
    dbgecho "trying checksum $checksumtype"
-   time $rdfind  -removeidentinode false -checksum $checksumtype speedtest/largefile1 speedtest/largefile2 > rdfind.out
+   time $rdfind  -removeidentinode false -checksum "$checksumtype" speedtest/largefile1 speedtest/largefile2 > rdfind.out
 done
 
 dbgecho "all is good in this test!"

--- a/testcases/common_funcs.sh
+++ b/testcases/common_funcs.sh
@@ -8,6 +8,11 @@ set -e
 
 me="$(basename "$0")"
 
+if [ "$WITH_XXHASH" = "1" ]; then
+    export allchecksumtypes="md5 sha1 sha256 sha512 xxh128"
+else
+    export allchecksumtypes="md5 sha1 sha256 sha512"
+fi
 
 # shellcheck disable=SC3037
 /bin/echo -n "$me: checking for rdfind ..."


### PR DESCRIPTION
this adds xxhash.

it is somewhere 5-10 times faster than sha1 when rdfind operates on large files (gigabytes) and no slower for small files.

this MR is coauthored with @trollkarlen based on the code in https://github.com/pauldreik/rdfind/pull/167 