### PR TITLE
fix typo in the man-page

### DIFF
--- a/rdfind.1
+++ b/rdfind.1
@@ -165,7 +165,7 @@ encountered as the most important (original), and the rest as
 duplicates. This might not be what you want.
 
 The symlink creates absolute links. This might not be what you
-want. To create relative links instead, you may use the symlink (2)
+want. To create relative links instead, you may use the symlinks(8)
 command, which is able to convert absolute links to relative links.
 
 Older versions unfortunately contained a misspelling on the word


### PR DESCRIPTION
Fixes https://github.com/pauldreik/rdfind/issues/188

Now I noticed that in `.SH "SEE ALSO"` it's correct.