### PR TITLE
Accept sizes with k/M/G/T/E suffixes.

### DIFF
--- a/CmdlineParser.hh
+++ b/CmdlineParser.hh
@@ -7,6 +7,8 @@
 #ifndef RDFIND_CMDLINEPARSER_HH_
 #define RDFIND_CMDLINEPARSER_HH_
 
+#include "Fileinfo.hh"    //for filesizetype
+
 /**
  * Command line parser, designed to be easy to use for rdfind.
  * It will signal user errors by a helpful printout followed by
@@ -49,6 +51,8 @@ public:
 
   bool current_arg_is(const char* what) const;
 
+  static Fileinfo::filesizetype read_file_size(char const *text);
+    
 private:
   const int m_argc{};
   const char** m_argv{};

--- a/rdfind.1
+++ b/rdfind.1
@@ -64,6 +64,9 @@ Ignore empty files. Setting this to true (the default) is equivalent to
 .BR \-minsize " "\fIN\fR
 Ignores files with less than N bytes. Default is 1, meaning empty files
 are ignored.
+
+File and buffer sizes can be given with suffix k, M, G etc. up to E,
+meaning powers of 1024.
 .TP
 .BR \-maxsize " "\fIN\fR
 Ignores files with N bytes or more. Default is 0, which means this check

--- a/rdfind.cc
+++ b/rdfind.cc
@@ -58,6 +58,9 @@ usage()
     << "                                  false implies -minsize 0)\n"
     << " -minsize N        (N=1)          ignores files with size less than N "
        "bytes\n"
+    << "                                  For -minsize, -maxsize and -buffersize,\n"
+       "                                  Suffixes 'K', 'M', 'G' etc. up to 'E'\n"
+       "                                  are accepted. Factors are 1024, not 1000.\n"
     << " -maxsize N        (N=0)          ignores files with size N "
        "bytes and larger (use 0 to disable this check).\n"
     << " -followsymlinks    true |(false) follow symlinks\n"
@@ -153,13 +156,13 @@ parseOptions(Parser& parser)
         o.minimumfilesize = 0;
       }
     } else if (parser.try_parse_string("-minsize")) {
-      const long long minsize = std::stoll(parser.get_parsed_string());
+        const long long minsize = Parser::read_file_size(parser.get_parsed_string());
       if (minsize < 0) {
         throw std::runtime_error("negative value of minsize not allowed");
       }
       o.minimumfilesize = minsize;
     } else if (parser.try_parse_string("-maxsize")) {
-      const long long maxsize = std::stoll(parser.get_parsed_string());
+        const long long maxsize = Parser::read_file_size(parser.get_parsed_string());
       if (maxsize < 0) {
         throw std::runtime_error("negative value of maxsize not allowed");
       }
@@ -199,7 +202,7 @@ parseOptions(Parser& parser)
         std::exit(EXIT_FAILURE);
       }
     } else if (parser.try_parse_string("-buffersize")) {
-      const long buffersize = std::stoll(parser.get_parsed_string());
+      const long buffersize = Parser::read_file_size(parser.get_parsed_string());
       constexpr long max_buffersize = 128 << 20;
       if (buffersize <= 0) {
         std::cerr << "a negative or zero buffersize is not allowed\n";


### PR DESCRIPTION
## Change
Have file and buffer size options accept arguments like '2k', '6M', '20G'.

## Reasoning
I typed something like: `rdfind -minsize 1G .` and got confusing output until I figured the 'G' suffix was not supported.
I would like such file size suffixes to work.

## Testing
To my shame, I did only cursorily test the new feature, and neglected to re-run the tests already present.

## Note
Thank you for sharing rdfind. Having to dedup a few TB on disk, I found it useful.
