### PR TITLE
Add option to partially hash files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ aclocal*
 autom4te*
 config.h
 ./config.h.in
+config.h.in
 config.log
 config.status
 configure
@@ -17,9 +18,11 @@ missing
 rdfind
 stamp-h1
 *~
+.idea
 
 compile
 test-driver
 nettle32bit/
 *.log
 rdfind-*.tar.gz
+results.txt

--- a/Fileinfo.hh
+++ b/Fileinfo.hh
@@ -139,11 +139,14 @@ public:
    * @param lasttype
    * @param buffer will be used as a scratch buffer - provided from the outside
    * to avoid having to reallocate it for each file
+   * @param partialchecksum when filltype is a CREATE_XXX_CHECKSUM type then
+   * only hash the first and last N MiB of the file skipping contents inbetween
    * @return zero on success
    */
   int fillwithbytes(enum readtobuffermode filltype,
                     enum readtobuffermode lasttype,
-                    std::vector<char>& buffer);
+                    std::vector<char>& buffer,
+                    int partialchecksum);
 
   /// get a pointer to the bytes read from the file
   const char* getbyteptr() const { return m_somebytes.data(); }

--- a/Rdutil.cc
+++ b/Rdutil.cc
@@ -543,7 +543,8 @@ int
 Rdutil::fillwithbytes(enum Fileinfo::readtobuffermode type,
                       enum Fileinfo::readtobuffermode lasttype,
                       const long nsecsleep,
-                      const std::size_t buffersize)
+                      const std::size_t buffersize,
+                      int partialchecksum)
 {
   // first sort on inode (to read efficiently from the hard drive)
   sortOnDeviceAndInode();
@@ -553,7 +554,7 @@ Rdutil::fillwithbytes(enum Fileinfo::readtobuffermode type,
   std::vector<char> buffer(buffersize, '\0');
 
   for (auto& elem : m_list) {
-    elem.fillwithbytes(type, lasttype, buffer);
+    elem.fillwithbytes(type, lasttype, buffer, partialchecksum);
     if (nsecsleep > 0) {
       std::this_thread::sleep_for(duration);
     }

--- a/Rdutil.hh
+++ b/Rdutil.hh
@@ -90,7 +90,8 @@ public:
   int fillwithbytes(enum Fileinfo::readtobuffermode type,
                     enum Fileinfo::readtobuffermode lasttype,
                     long nsecsleep,
-                    std::size_t buffersize);
+                    std::size_t buffersize,
+                    int partialchecksum);
 
   /// make symlinks of duplicates.
   std::size_t makesymlinks(bool dryrun) const;


### PR DESCRIPTION
Adds the `-partialchecksum` option which takes in the number of MB to be hashed from the start and end of the file instead of hashing the whole file.

This option is set to 0 by default which means it is disabled.

When it is set to a value like 1, the first 1mb of the file would be read, the we'd skip head to file_size - 1mb and read that last 1mb to compute the checksum.
This option will only take info effect if file_size > 2 * partial checksum size.

This has the tradeoff of much quicker hashing times (the different hashing algos don't matter much where you're limited by disk speed) at the risk of false positives.