### PR TITLE
Fix dry run text in output

### DIFF
--- a/rdfind.cc
+++ b/rdfind.cc
@@ -382,7 +382,7 @@ main(int narg, const char* argv[])
             << " bytes or ";
   gswd.totalsize(std::cout) << std::endl;
 
-  std::cout << "Removed " << gswd.removeUniqueSizes()
+  std::cout << dryruntext << "Removed " << gswd.removeUniqueSizes()
             << " files due to unique sizes from list. ";
   std::cout << filelist.size() << " files left." << std::endl;
 


### PR DESCRIPTION
Just a little fix to add the dry run text in all outputs. Before this fix I had this output:
```
> rdfind -dryrun true .
(DRYRUN MODE) Now scanning ".", found 87452 files.
(DRYRUN MODE) Now have 87452 files in total.
(DRYRUN MODE) Removed 46307 files due to nonunique device and inode.
(DRYRUN MODE) Total size is 305721199431 bytes or 285 GiB
Removed 3458 files due to unique sizes from list. 37687 files left.
(DRYRUN MODE) Now eliminating candidates based on first bytes: removed 12 files from list. 37675 files left.
(DRYRUN MODE) Now eliminating candidates based on last bytes: removed 2 files from list. 37673 files left.```