### PR TITLE
add progress option (closes #30)

### DIFF
--- a/Rdutil.cc
+++ b/Rdutil.cc
@@ -543,7 +543,8 @@ int
 Rdutil::fillwithbytes(enum Fileinfo::readtobuffermode type,
                       enum Fileinfo::readtobuffermode lasttype,
                       const long nsecsleep,
-                      const std::size_t buffersize)
+                      const std::size_t buffersize,
+                      std::function<void(std::size_t)> progress_cb)
 {
   // first sort on inode (to read efficiently from the hard drive)
   sortOnDeviceAndInode();
@@ -551,8 +552,13 @@ Rdutil::fillwithbytes(enum Fileinfo::readtobuffermode type,
   const auto duration = std::chrono::nanoseconds{ nsecsleep };
 
   std::vector<char> buffer(buffersize, '\0');
+  std::size_t progress_count = 0;
 
   for (auto& elem : m_list) {
+    if (progress_cb) {
+      ++progress_count;
+      progress_cb(progress_count);
+    }
     elem.fillwithbytes(type, lasttype, buffer);
     if (nsecsleep > 0) {
       std::this_thread::sleep_for(duration);

--- a/Rdutil.hh
+++ b/Rdutil.hh
@@ -9,6 +9,7 @@
 #ifndef rdutil_hh
 #define rdutil_hh
 
+#include <functional>
 #include <vector>
 
 #include "Fileinfo.hh" //file container
@@ -90,7 +91,8 @@ public:
   int fillwithbytes(enum Fileinfo::readtobuffermode type,
                     enum Fileinfo::readtobuffermode lasttype,
                     long nsecsleep,
-                    std::size_t buffersize);
+                    std::size_t buffersize,
+                    std::function<void(std::size_t)> progress_cb);
 
   /// make symlinks of duplicates.
   std::size_t makesymlinks(bool dryrun) const;

--- a/rdfind.1
+++ b/rdfind.1
@@ -115,6 +115,9 @@ Delete (unlink) files. Default is false.
 .PP
 General options:
 .TP
+.BR \-progress " " \fItrue\fR|\fIfalse\fR
+Show progress during elimination. Defaults to false.
+.TP
 .BR \-sleep " " \fIX\fRms
 Sleeps X milliseconds between reading each file, to reduce
 load. Default is 0 (no sleep). Note that only a few values are


### PR DESCRIPTION
Thanks @entrity and @t-oster for the work and the patience. This PR is built on top of your work in https://github.com/pauldreik/rdfind/pull/42 and https://github.com/pauldreik/rdfind/pull/190. I made some simplifications by using a std::function and caching the constant output, instead of a function pointer.

closes #30 