### PR TITLE
progress: call outer lamba each stage, so filelist size is updated

### DIFF
--- a/Rdutil.cc
+++ b/Rdutil.cc
@@ -544,8 +544,12 @@ Rdutil::fillwithbytes(enum Fileinfo::readtobuffermode type,
                       enum Fileinfo::readtobuffermode lasttype,
                       const long nsecsleep,
                       const std::size_t buffersize,
-                      std::function<void(std::size_t)> progress_cb)
+                      std::function<std::function<void(std::size_t)>(void)> progress_cb_f)
 {
+  std::function<void(std::size_t)> progress_cb;
+  if (progress_cb_f) {
+    progress_cb = progress_cb_f();
+  }
   // first sort on inode (to read efficiently from the hard drive)
   sortOnDeviceAndInode();
 

--- a/Rdutil.hh
+++ b/Rdutil.hh
@@ -92,7 +92,7 @@ public:
                     enum Fileinfo::readtobuffermode lasttype,
                     long nsecsleep,
                     std::size_t buffersize,
-                    std::function<void(std::size_t)> progress_cb);
+                    std::function<std::function<void(std::size_t)>(void)> progress_cb_f);
 
   /// make symlinks of duplicates.
   std::size_t makesymlinks(bool dryrun) const;

--- a/rdfind.cc
+++ b/rdfind.cc
@@ -414,7 +414,7 @@ main(int narg, const char* argv[])
                        "xxh128 checksum");
   }
 
-  std::function<void(std::size_t)> progress_callback;
+  std::function<std::function<void(std::size_t)>(void)> progress_callback;
   if (o.showprogress) {
     progress_callback = []() {
       // format the total count only once, not each iteration.
@@ -426,7 +426,7 @@ main(int narg, const char* argv[])
           << "\033[s\033[K" // Save the cursor position & clear following text
           << "(" << completed << suffix << std::flush;
       };
-    }();
+    };
   }
 
   for (auto it = modes.begin() + 1; it != modes.end(); ++it) {


### PR DESCRIPTION
output before was:
```
src/rdfind $ ./rdfind -sleep 100ms -progress false -n true .
[...]
Removed 175 files due to unique sizes from list. 51 files left. 
(DRYRUN MODE) Now eliminating candidates based on first bytes: (x/51) ... removed 29 files from list. 22 files left. 
(DRYRUN MODE) Now eliminating candidates based on last bytes: (x/51) ... removed 9 files from list. 13 files left. 
(DRYRUN MODE) Now eliminating candidates based on sha1 checksum: (x/51) ... removed 2 files from list. 11 files left. 
(DRYRUN MODE) It seems like you have 11 files that are not unique 
[...]
```
now it will be:
```
src/rdfind $ ./rdfind -sleep 100ms -progress true -n true . 
[...]
Removed 175 files due to unique sizes from list. 51 files left. 
(DRYRUN MODE) Now eliminating candidates based on first bytes: (x/51) ... removed 29 files from list. 22 files left. 
(DRYRUN MODE) Now eliminating candidates based on last bytes: (x/22) ... removed 9 files from list. 13 files left. 
(DRYRUN MODE) Now eliminating candidates based on sha1 checksum: (x/11) ... removed 2 files from list. 11 files left. 
(DRYRUN MODE) It seems like you have 11 files that are not unique 
[...]
```